### PR TITLE
Update main.yml

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,9 +27,19 @@ jobs:
       - name: Run basic Streamlit test
         run: |
           echo "Testing Streamlit app launch"
-          streamlit run login.py --server.headless true &
+          # Run Streamlit app in the background and log output
+          nohup streamlit run login.py --server.headless true & 
+          STREAMLIT_PID=$!
           sleep 10
-          pkill streamlit
+          # Check if Streamlit is running, and then kill the process
+          if ps -p $STREAMLIT_PID > /dev/null; then
+            echo "Streamlit app launched successfully"
+            kill $STREAMLIT_PID
+          else
+            echo "Streamlit app failed to launch"
+            exit 1
+          fi
 
       - name: ✅ CI Success Message
         run: echo "Streamlit app passed CI test ✅"
+


### PR DESCRIPTION
Graceful Process Management:

We use nohup to run the Streamlit app in the background and store its process ID (STREAMLIT_PID).

After 10 seconds, we check if the Streamlit app is still running using ps -p $STREAMLIT_PID. If it is, we kill the process and report success. If it isn't running, we exit the script with an error (exit 1), indicating the test failed.

Logging:

Adding checks like ps -p $STREAMLIT_PID ensures you can see if the app launched properly before killing the process.

What Happens Now:
If the Streamlit app starts successfully, it will be terminated after 10 seconds, and the workflow will output "Streamlit app passed CI test ✅".

If there’s an issue with launching Streamlit, the workflow will fail, and you'll get an error message in the logs.

This makes the testing process more robust and ensures that the Streamlit app is properly checked before proceeding.